### PR TITLE
Fixes malformed manifest.json

### DIFF
--- a/app/assets/javascripts/manifest.json.erb
+++ b/app/assets/javascripts/manifest.json.erb
@@ -6,7 +6,7 @@
   "orientation": "portrait",
   "background_color": "#dd8923",
    "icons": [{
-     "src": <%= image_path "circle-turtle-192x192.png" %>,
+     "src": "<%= image_path "circle-turtle-192x192.png" %>",
      "sizes": "192x192",
      "type": "image/png"
   }]


### PR DESCRIPTION
You were producing a src link without wrapping it in quotes so the application manifest.json wasn't being parsed correctly. You can easily check this by going to the sandbox website and inspecting the application tab using chrome.